### PR TITLE
Resized the screen, tiles and images due to partial visibility. 

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 class Tile(pg.sprite.Sprite):
-    tilesize = 180
+    tilesize = 90
 
     def __init__(self, x, y):
         super().__init__()
@@ -21,7 +21,10 @@ class Piece(pg.sprite.Sprite):
         self.x = x
         self.y = y
         self.color = color
-        self.image = pg.image.load(self.resource_path(f"images/{color}/{color}_{type}.png"))
+
+        raw_image = pg.image.load(self.resource_path(f"images/{color}/{color}_{type}.png"))
+        self.image = pg.transform.smoothscale(raw_image, (Tile.tilesize, Tile.tilesize))
+
         self.rect = pg.Rect(x * Tile.tilesize, y * Tile.tilesize, Tile.tilesize, Tile.tilesize)
         self.movable_tiles = []
         self.moved = False
@@ -34,6 +37,7 @@ class Piece(pg.sprite.Sprite):
             base_path = os.path.abspath(".")
 
         return os.path.join(base_path, relative_path)
+
 
 
     def kill(self, live_pieces, dead_pieces):

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from classes import *
 
 
 def main():
-    screen = pg.display.set_mode((1440, 1440))
+    screen = pg.display.set_mode((720, 720))
     pg.display.set_caption('Chess')
     chess_grid = {i: {j: None for j in range(8)} for i in range(8)}
     board = pg.sprite.Group()


### PR DESCRIPTION
### I transformed the pieces as per tiles dimension, earlier the images were rendered as it is. 

When i opened the game, the screen was bigger than my system's screen and the pieces were partially visible. Changing the window size doesn't do anything as the size of tiles were still big and the whole board wasn't captured in the window. I basically modified the size of screen and tiles so that it's perfectly visible. I also noticed the size of images (pieces) were rendered as it is (160 x 160). I transformed and rescaled the image to the size proportional to the chess board.